### PR TITLE
Remove matching AtRules

### DIFF
--- a/lib/css-byebye.js
+++ b/lib/css-byebye.js
@@ -77,6 +77,16 @@ var cssbyebye = postcss.plugin('css-byebye', function (options) {
         rule.remove()
       }
     }
+
+    css.walkAtRules(filterAtRule)
+
+    function filterAtRule (rule) {
+      var ruleName = '@' + rule.name
+
+      if (ruleName.match(regex) !== null) {
+        rule.remove()
+      }
+    }
   }
 })
 

--- a/lib/css-byebye.spec.js
+++ b/lib/css-byebye.spec.js
@@ -36,4 +36,15 @@ describe('cssbyebye', function () {
     assert.strictEqual(result.css, expected)
     done()
   })
+
+  it('should remove at-rules', function (done) {
+    var css = '@charset "UTF-8"; @font-face { font-family: "Font Name" } #id { color: red }'
+    var rulesToRemove = ['@charset', '@font-face']
+    var expected = '#id { color: red }'
+    var options = { rulesToRemove: rulesToRemove, map: false }
+    var result = postcss(cssbyebye(options)).process(css)
+
+    assert.strictEqual(result.css, expected)
+    done()
+  })
 })


### PR DESCRIPTION
Use `walkAtRules` to check for matches to things like `@font-face`,
`@charset`, etc.

Closes #9